### PR TITLE
refactor: sourcemap control, apollo server port dynamic, port as argument

### DIFF
--- a/packages/graphpack/bin/graphpack.js
+++ b/packages/graphpack/bin/graphpack.js
@@ -37,14 +37,11 @@ const startGraphPack = async () => {
   const compiler = webpack(config);
 
   require('yargs')
-    .command(['$0', 'dev'], 'Start graphpack dev server', {}, (yargs) => {
+    .command(['$0', 'dev'], 'Start graphpack dev server', {}, yargs => {
       process.env.PORT = yargs.port || yargs.p || yargs.PORT || yargs.P;
       startDevServer({ compiler, config });
     })
-    .command('build', 'Create production build', {}, (yargs) => {
-      process.env.PORT = yargs.port || yargs.p || yargs.PORT || yargs.P;
-      createProductionBuild({ compiler });
-    }).argv;
+    .command('build', 'Create production build', {}, () => createProductionBuild({ compiler })).argv;
 };
 
 startGraphPack();

--- a/packages/graphpack/bin/graphpack.js
+++ b/packages/graphpack/bin/graphpack.js
@@ -37,12 +37,14 @@ const startGraphPack = async () => {
   const compiler = webpack(config);
 
   require('yargs')
-    .command(['$0', 'dev'], 'Start graphpack dev server', {}, () =>
-      startDevServer({ compiler, config }),
-    )
-    .command('build', 'Create production build', {}, () =>
-      createProductionBuild({ compiler }),
-    ).argv;
+    .command(['$0', 'dev'], 'Start graphpack dev server', {}, (yargs) => {
+      process.env.PORT = yargs.port || yargs.p || yargs.PORT || yargs.P;
+      startDevServer({ compiler, config });
+    })
+    .command('build', 'Create production build', {}, (yargs) => {
+      process.env.PORT = yargs.port || yargs.p || yargs.PORT || yargs.P;
+      createProductionBuild({ compiler });
+    }).argv;
 };
 
 startGraphPack();

--- a/packages/graphpack/config/webpack.config.js
+++ b/packages/graphpack/config/webpack.config.js
@@ -12,7 +12,7 @@ if (hasBabelRc) {
 }
 
 module.exports = {
-  devtool: 'sourcemap',
+  devtool: IS_DEV ? 'sourcemap': 'none',
   entry: {
     // We take care of setting up entry file under lib/index.js
     index: ['graphpack'],
@@ -58,7 +58,7 @@ module.exports = {
     filename: '[name].js',
     libraryTarget: 'commonjs2',
     path: path.join(process.cwd(), './build'),
-    sourceMapFilename: '[name].map',
+    sourceMapFilename: '[name].map'
   },
   performance: {
     hints: false,

--- a/packages/graphpack/lib/server.js
+++ b/packages/graphpack/lib/server.js
@@ -29,7 +29,7 @@ const server = new ApolloServer({
 });
 
 server
-  .listen({ port: (config.PORT || config.port) || (process.env.PORT || 4000) })
+  .listen({ port: ((config.PORT || config.port) || (process.env.PORT || 4000)) })
   .then(({ url }) => console.log(`🚀 Server ready at ${url}`));
 
 export default server;

--- a/packages/graphpack/lib/server.js
+++ b/packages/graphpack/lib/server.js
@@ -29,7 +29,7 @@ const server = new ApolloServer({
 });
 
 server
-  .listen({ port: 4000 })
+  .listen({ port: (config.PORT || config.port) || (process.env.PORT || 4000) })
   .then(({ url }) => console.log(`🚀 Server ready at ${url}`));
 
 export default server;


### PR DESCRIPTION
This PR contains below features.

1. Sourcemap (webpack generated) now it will be only in `production` mode.
2. Apollo server port now fully dynamically configured through `config` object and `process`.
3. Now during `graphpack` dev build port can be passed as argument.

BTW! `graphpack` awesome :+1: 