### PR TITLE
TypeScript fixes and added GraphQL Code Generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,5 @@
     "prettier": "^1.14.3",
     "pretty-quick": "^1.8.0"
   },
-  "dependencies": {
-    "ts-loader": "^5.2.2"
-  }
+  "dependencies": {}
 }

--- a/packages/graphpack/bin/graphpack.js
+++ b/packages/graphpack/bin/graphpack.js
@@ -36,7 +36,7 @@ const createProductionBuild = ({ compiler }) => {
 const generateSchemaTypings = (watch = false) => {
   const srcPath = process.env.GRAPHPACK_SRC_DIR || `${process.cwd()}/src/`;
   const schemaFilesRegex = path.join(srcPath, './**/*.graphql');
-  
+
   generate({
     schema: schemaFilesRegex,
     template: 'graphql-codegen-typescript-template',
@@ -45,7 +45,7 @@ const generateSchemaTypings = (watch = false) => {
     watch,
     overwrite: true,
   });
-}
+};
 
 const startGraphPack = async () => {
   const config = await loadWebpackConfig();

--- a/packages/graphpack/bin/graphpack.js
+++ b/packages/graphpack/bin/graphpack.js
@@ -3,6 +3,7 @@ const nodemon = require('nodemon');
 const path = require('path');
 const { once } = require('ramda');
 const webpack = require('webpack');
+const { generate } = require('graphql-code-generator');
 const { loadWebpackConfig } = require('../config');
 
 const startDevServer = ({ compiler, config }) => {
@@ -32,17 +33,33 @@ const createProductionBuild = ({ compiler }) => {
   });
 };
 
+const generateSchemaTypings = (watch = false) => {
+  const srcPath = process.env.GRAPHPACK_SRC_DIR || `${process.cwd()}/src/`;
+  const schemaFilesRegex = path.join(srcPath, './**/*.graphql');
+  
+  generate({
+    schema: schemaFilesRegex,
+    template: 'graphql-codegen-typescript-template',
+    out: path.join(srcPath, 'graphql-typings.ts'),
+    args: [],
+    watch,
+    overwrite: true,
+  });
+}
+
 const startGraphPack = async () => {
   const config = await loadWebpackConfig();
   const compiler = webpack(config);
 
   require('yargs')
-    .command(['$0', 'dev'], 'Start graphpack dev server', {}, () =>
-      startDevServer({ compiler, config }),
-    )
-    .command('build', 'Create production build', {}, () =>
-      createProductionBuild({ compiler }),
-    ).argv;
+    .command(['$0', 'dev'], 'Start graphpack dev server', {}, () => {
+      generateSchemaTypings(true);
+      startDevServer({ compiler, config });
+    })
+    .command('build', 'Create production build', {}, () => {
+      generateSchemaTypings(false);
+      createProductionBuild({ compiler });
+    }).argv;
 };
 
 startGraphPack();

--- a/packages/graphpack/package.json
+++ b/packages/graphpack/package.json
@@ -30,6 +30,8 @@
     "ramda": "^0.25.0",
     "webpack": "^4.20.2",
     "webpack-node-externals": "^1.7.2",
-    "yargs": "^12.0.2"
+    "yargs": "^12.0.2",
+    "ts-loader": "^5.2.2",
+    "typescript": "^3.1.3"
   }
 }

--- a/packages/graphpack/package.json
+++ b/packages/graphpack/package.json
@@ -25,6 +25,8 @@
     "cosmiconfig": "^5.0.6",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "graphql": "^0.13.2",
+    "graphql-code-generator": "^0.12.6",
+    "graphql-codegen-typescript-template": "^0.12.6",
     "graphql-tag": "^2.9.2",
     "nodemon": "^1.18.4",
     "ramda": "^0.25.0",


### PR DESCRIPTION
This PR includes some fixes related to the TypeScript support branch:
- Move `ts-loader` to the correct place.
- Added missing `typescript` dependency.
- Added `graphql-code-generator` with TypeScript template. It includes generated typings for the entire schema and for `resolvers` signature.

I can recommend the following `tsconfig.json`, but I think this package should just use it from the project's directory and not include it internally, otherwise IDEs wont detect that it's a TypeScript project.

```json
{
  "compilerOptions": {
    "lib": ["es2017", "esnext.asynciterable", "dom"],
    "target": "es2017",
    "module": "commonjs",
    "moduleResolution": "node",
    "sourceMap": true,
    "experimentalDecorators": true,
    "emitDecoratorMetadata": true,
    "outDir": "dist",
    "allowSyntheticDefaultImports": true
  },
  "include": ["src/**/*"],
  "exclude": ["node_modules"]
}
```