### PR TITLE
fix(readme): remove double `mocks` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ module.exports = (mode) => {
     introspection: IS_DEV,
     playground: IS_DEV,
     mocks: IS_DEV,
-    mocks: IS_DEV,
     // ...
   }
 };


### PR DESCRIPTION
Thanks for the package! Saw this when reading through the readme. Hope it makes sense.